### PR TITLE
add copyq plugin (history access)

### DIFF
--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -37,7 +37,7 @@ build_json() {
     "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
     "description": "$count",
     "actions": [{
-        "name": "$row",
+        "name": "copy $row to clipboard",
         "command": "copyq",
         "arguments": ["select", "$count"]
     }]

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -19,8 +19,7 @@ send_metadata() {
 copyq_get_row() {
     local copyq_row
     local count="$1"
-    copyq_row="$(copyq read "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
-
+    copyq_row="$(copyq read text/plain "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
     # clean from non compatible json char
     printf -v clean_copyq_row "%q" "$copyq_row"
     echo -n "$clean_copyq_row"
@@ -59,6 +58,9 @@ build_albert_query() {
     else
         for count in {0..10}; do
             row=$(copyq_get_row "$count")
+            if [[ "$row" == "''" ]]; then
+                continue
+            fi
             new=$(build_json "$count" "$row")
 
             json="$json$new"

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -o pipefail -o nounset
+
 copyq_get_row(){
     local copyq_row="$(copyq read $1 | head -1 | sed -e 's/^[[:space:]]*//')"
 
@@ -69,6 +71,7 @@ main() {
         ;;
 
         "QUERY")
+            ALBERT_QUERY=${ALBERT_QUERY:-}
             QUERYSTRING="${ALBERT_QUERY:2}"
             build_albert_query "$QUERYSTRING"
             exit 0

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -80,7 +80,7 @@ main() {
 
         "QUERY")
             ALBERT_QUERY=${ALBERT_QUERY:-}
-            QUERYSTRING="${ALBERT_QUERY:2}"
+            QUERYSTRING="${ALBERT_QUERY:5}"
             build_albert_query "$QUERYSTRING"
             exit 0
         ;;

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -36,13 +36,14 @@ build_albert_query() {
     local count="$1"
     local return='{"items":['
     local json=''
+    local row
 
     if [[ $count =~ ^-?[0-9]+$ ]]; then
-        local row=$(copyq_get_row "$count")
+        row=$(copyq_get_row "$count")
         json=$(build_json "$count" "$row")
     else
         for count in {0..10}; do
-            local row=$(copyq_get_row "$count")
+            row=$(copyq_get_row "$count")
             new=$(build_json "$count" "$row")
 
             json="$json$new"

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -2,8 +2,24 @@
 
 set -e -o pipefail -o nounset
 
-copyq_get_row(){
-    local copyq_row="$(copyq read $1 | head -1 | sed -e 's/^[[:space:]]*//')"
+send_metadata() {
+    local metadata
+
+    metadata='{
+    "iid":"org.albert.extension.external/v2.0",
+    "name":"Clipboard Manager",
+    "version":"1.2",
+    "author":"BarbUk",
+    "dependencies":["copyq"],
+    "trigger":"h"
+}'
+    echo -n "${metadata}"
+}
+
+copyq_get_row() {
+    local copyq_row
+    local count="$1"
+    copyq_row="$(copyq read "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
 
     # clean from non compatible json char
     printf -v clean_copyq_row "%q" "$copyq_row"
@@ -59,15 +75,7 @@ build_albert_query() {
 main() {
     case $ALBERT_OP in
         "METADATA")
-            STDOUT='{
-                "iid":"org.albert.extension.external/v2.0",
-                "name":"Clipboard Manager",
-                "version":"1.1",
-                "author":"BarbUk",
-                "dependencies":["copyq"],
-                "trigger":"h"
-            }'
-            echo -n "${STDOUT}"
+            send_metadata
             exit 0
         ;;
 

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -11,7 +11,7 @@ send_metadata() {
     "version":"1.2",
     "author":"BarbUk",
     "dependencies":["copyq"],
-    "trigger":"hist"
+    "trigger":"cq "
 }'
     echo -n "${metadata}"
 }

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -29,7 +29,7 @@ build_json() {
 },
 EOM
 
-    echo -n $json
+    echo -n "$json"
 }
 
 build_albert_query() {

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+copyq_get_row(){
+    local copyq_row="$(copyq read $1 | head -1 | sed -e 's/^[[:space:]]*//')"
+
+    # clean from non compatible json char
+    printf -v clean_copyq_row "%q" "$copyq_row"
+    echo -n "$clean_copyq_row"
+}
+
+build_json() {
+    local count="$1"
+    shift 1
+    local row="$*"
+
+    read -r -d '' json << EOM
+{
+    "id": "h$count",
+    "name": "$row",
+    "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
+    "description": "$count",
+    "actions": [{
+        "name": "$row",
+        "command": "copyq",
+        "arguments": ["select", "$count"]
+    }]
+},
+EOM
+
+    echo -n $json
+}
+
+build_albert_query() {
+    local count="$1"
+    local return='{"items":['
+    local json=''
+
+    if [[ $count =~ ^-?[0-9]+$ ]]; then
+        local row=$(copyq_get_row "$count")
+        json=$(build_json "$count" "$row")
+    else
+        for count in {0..10}; do
+            local row=$(copyq_get_row "$count")
+            new=$(build_json "$count" "$row")
+
+            json="$json$new"
+        done
+    fi
+    # remove last comma
+    json=${json::-1}
+
+    return="$return$json]}"
+    echo -n "$return"
+}
+
+main() {
+    case $ALBERT_OP in
+        "METADATA")
+            STDOUT='{
+                "iid":"org.albert.extension.external/v2.0",
+                "name":"Clipboard Manager",
+                "version":"1.1",
+                "author":"BarbUk",
+                "dependencies":["copyq"],
+                "trigger":"h"
+            }'
+            echo -n "${STDOUT}"
+            exit 0
+        ;;
+
+        "QUERY")
+            QUERYSTRING="${ALBERT_QUERY:2}"
+            build_albert_query "$QUERYSTRING"
+            exit 0
+        ;;
+        "INITIALIZE")
+    	    exit 0
+    	;;
+  	    "FINALIZE")
+    	    exit 0
+    	;;
+  	    "SETUPSESSION")
+    	    exit 0
+    	;;
+  	    "TEARDOWNSESSION")
+    	    exit 0
+    	;;
+    esac
+}
+main

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -33,7 +33,6 @@ build_json() {
 
     read -r -d '' json << EOM
 {
-    "id": "h$count",
     "name": "$row",
     "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
     "description": "$count",

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -11,7 +11,7 @@ send_metadata() {
     "version":"1.2",
     "author":"BarbUk",
     "dependencies":["copyq"],
-    "trigger":"h"
+    "trigger":"hist"
 }'
     echo -n "${metadata}"
 }


### PR DESCRIPTION
As commented in the issue https://github.com/albertlauncher/albert/issues/255, this is a plugin to access copyq history.