### PR TITLE
add CopyQ Snippets tab extension

### DIFF
--- a/org.albert.extension.external.copyq-snippets.sh
+++ b/org.albert.extension.external.copyq-snippets.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+## Exit on error, var unset and pipefail
+set -e -o pipefail -o nounset
+
+send_metadata() {
+    local metadata
+
+    metadata='{
+    "iid":"org.albert.extension.external/v2.0",
+    "name":"Snippets Manager",
+    "version":"0.1",
+    "author":"turuflowers",
+    "dependencies":["copyq", "xdotool"],
+    "trigger":"s "
+}'
+    echo -n "${metadata}"
+}
+
+## get a row from copyq Snippets tab
+copyq_get_row() {
+    local copyq_row
+    local count="$1"
+    local n
+
+    ## I take just the first line, in case there is a block of text
+    copyq_row="$(copyq tab Snippets read text/plain "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
+    n="$(copyq tab Snippets read application/x-copyq-item-notes "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
+
+    # clean from non compatible json char
+    printf -v clean_copyq_row "%q" "$n"
+    echo -n "$clean_copyq_row"
+}
+
+## Build json object for albert query
+build_json() {
+    local count="$1"
+    shift 1
+    local row="$*"
+
+    read -r -d '' json << EOM
+{
+    "name": "$row",
+    "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
+    "description": "$count $row",
+    "actions": [{
+        "name": "copy $row to clipboard",
+        "command": "copyq",
+        "arguments": ["tab", "Snippets", "select", "$count"]
+    },{
+        "name": "paste $row to active window",
+	"command": "xdotool",
+	"arguments": ["key", "--clearmodifiers", "ctrl+v"]
+    }
+    ]
+},
+EOM
+
+    echo -n "$json"
+}
+
+build_albert_query() {
+    local count="$1"
+    local return='{"items":['
+    local json=''
+    local row
+
+    ## If the query is a number, just get that row from
+    ## copyq Snippets tab
+    if [[ $count =~ ^-?[0-9]+$ ]]; then
+        row=$(copyq_get_row "$count")
+        json=$(build_json "$count" "$row")
+    else
+        ## else get the last 11
+        for count in {0..10}; do
+            row=$(copyq_get_row "$count")
+            if [[ "$row" == "''" ]]; then
+                continue
+            fi
+            new=$(build_json "$count" "$row")
+
+            json="$json$new"
+        done
+    fi
+
+    # remove last comma
+    json=${json::-1}
+
+    return="$return$json]}"
+    echo -n "$return"
+}
+
+main() {
+    case $ALBERT_OP in
+        "METADATA")
+            send_metadata
+            exit 0
+        ;;
+
+        "QUERY")
+            ALBERT_QUERY=${ALBERT_QUERY:-}
+            QUERYSTRING="${ALBERT_QUERY:3}"
+            build_albert_query "$QUERYSTRING"
+            exit 0
+        ;;
+        "INITIALIZE")
+    	    exit 0
+    	;;
+  	    "FINALIZE")
+    	    exit 0
+    	;;
+  	    "SETUPSESSION")
+    	    exit 0
+    	;;
+  	    "TEARDOWNSESSION")
+    	    exit 0
+    	;;
+    esac
+}
+
+## Call the main function
+main

--- a/org.albert.extension.external.copyq-snippets.sh
+++ b/org.albert.extension.external.copyq-snippets.sh
@@ -9,7 +9,7 @@ send_metadata() {
     metadata='{
     "iid":"org.albert.extension.external/v2.0",
     "name":"Snippets Manager",
-    "version":"0.1",
+    "version":"0.2",
     "author":"turuflowers",
     "dependencies":["copyq"],
     "trigger":"s "
@@ -46,13 +46,9 @@ build_json() {
     "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
     "description": "$count",
     "actions": [{
-        "name": "copy $row to clipboard",
+        "name": "copy/paste $row",
         "command": "copyq",
-        "arguments": ["tab", "Snippets", "select", "$count"]
-        },{
-        "name": "paste...",
-        "command": "copyq",
-        "arguments": ["paste"]
+        "arguments": ["tab", "Snippets", "text = read($count); copy(text); copySelection(text); paste()"]
         }
     ]
 },

--- a/org.albert.extension.external.copyq-snippets.sh
+++ b/org.albert.extension.external.copyq-snippets.sh
@@ -11,7 +11,7 @@ send_metadata() {
     "name":"Snippets Manager",
     "version":"0.1",
     "author":"turuflowers",
-    "dependencies":["copyq", "xdotool"],
+    "dependencies":["copyq"],
     "trigger":"s "
 }'
     echo -n "${metadata}"
@@ -25,6 +25,8 @@ copyq_get_row() {
 
     ## I take just the first line, in case there is a block of text
     copyq_row="$(copyq tab Snippets read text/plain "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
+
+    ## I take the name from the Note
     n="$(copyq tab Snippets read application/x-copyq-item-notes "$count" | head -1 | sed -e 's/^[[:space:]]*//')"
 
     # clean from non compatible json char
@@ -42,16 +44,16 @@ build_json() {
 {
     "name": "$row",
     "icon": "/usr/share/icons/hicolor/scalable/apps/copyq-normal.svg",
-    "description": "$count $row",
+    "description": "$count",
     "actions": [{
         "name": "copy $row to clipboard",
         "command": "copyq",
         "arguments": ["tab", "Snippets", "select", "$count"]
-    },{
-        "name": "paste $row to active window",
-	"command": "xdotool",
-	"arguments": ["key", "--clearmodifiers", "ctrl+v"]
-    }
+        },{
+        "name": "paste...",
+        "command": "copyq",
+        "arguments": ["paste"]
+        }
     ]
 },
 EOM


### PR DESCRIPTION
Based on the work of @BarbUk. 

The idea is to mimmic the Snippets functionality of Alfred. In this case, Albert will filter after "s " between the content of the tab named "Snippets".

For now it will copy the content, but to make it work exactly like Alfred, it should also paste the content to "the last active window". I can't make it work.

This functionality can be on CopyQ with this command:
https://github.com/hluk/copyq-commands/blob/master/Global/snippets.ini (by @hluk)

It will be nice to have it all on Albert.