### PR TITLE
Copyq clipboard history: New action

### DIFF
--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -45,7 +45,7 @@ build_json() {
         {
             "name": "paste directly",
             "command": "copyq",
-            "arguments": ["select($count); sleep(50); paste()"]
+            "arguments": ["select($count); sleep(60); paste()"]
         },
         {
             "name": "copy to clipboard",

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -12,7 +12,7 @@ send_metadata() {
     "version":"1.3",
     "author":"BarbUk",
     "dependencies":["copyq"],
-    "trigger":"cq "
+    "trigger":"cq"
 }'
     echo -n "${metadata}"
 }
@@ -99,7 +99,7 @@ main() {
 
         "QUERY")
             ALBERT_QUERY=${ALBERT_QUERY:-}
-            QUERYSTRING="${ALBERT_QUERY:3}"
+            QUERYSTRING="${ALBERT_QUERY:2}"
             build_albert_query "$QUERYSTRING"
             exit 0
         ;;

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -9,7 +9,7 @@ send_metadata() {
     metadata='{
     "iid":"org.albert.extension.external/v2.0",
     "name":"Clipboard Manager",
-    "version":"1.3",
+    "version":"1.4",
     "author":"BarbUk",
     "dependencies":["copyq"],
     "trigger":"cq"

--- a/org.albert.extension.external.copyq.sh
+++ b/org.albert.extension.external.copyq.sh
@@ -41,11 +41,18 @@ build_json() {
     "name": "$row",
     "icon": "copyq-normal",
     "description": "$count",
-    "actions": [{
-        "name": "copy $row to clipboard",
-        "command": "copyq",
-        "arguments": ["select($count); sleep(50); paste()"]
-    }]
+    "actions": [
+        {
+            "name": "paste directly",
+            "command": "copyq",
+            "arguments": ["select($count); sleep(50); paste()"]
+        },
+        {
+            "name": "copy to clipboard",
+            "command": "copyq",
+            "arguments": ["select", "$count"]
+        }
+    ]
 },
 EOM
 


### PR DESCRIPTION
Following your comment https://github.com/albertlauncher/external/commit/43caa6b3d7ea2b1bd0a231011248061b73167993#commitcomment-24427512,
I've added a new action to choose between directly pasting or copying in the clipboard.

I've also added 10ms to the sleep function before pasting.